### PR TITLE
Tl/check if config exists

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -26,6 +26,8 @@ var (
 
 // pgproxy Main
 func Main(config interface{}, pargs interface{}) {
+	var proxyconf = flag.String("config", "pgproxy.conf", "configuration file for pgproxy")
+
 	flag.Parse()
 
 	var args []string
@@ -33,7 +35,7 @@ func Main(config interface{}, pargs interface{}) {
 		pc, connStr = readConfig(config.(string))
 		args = pargs.([]string)
 	} else {
-		pc, connStr = readConfig("./pgproxy.conf")
+		pc, connStr = readConfig(*proxyconf)
 		args = os.Args
 	}
 
@@ -44,7 +46,7 @@ func Main(config interface{}, pargs interface{}) {
 	} else {
 		if args[1] == "start" {
 			glog.Infoln("Starting pgproxy...")
-			info()
+			info(pc.ServerConfig.ProxyAddr)
 			logDir()
 			saveCurrentPid()
 			proxy.Start(pc.ServerConfig.ProxyAddr, pc.DB["master"].Addr, parser.Filter, parser.Return)
@@ -69,18 +71,19 @@ func help() {
 }
 
 // print pgproxy infomation
-func info() {
+func info(proxyhost string) {
+	fmt.Println(Logo)
 	hostname, err := os.Hostname()
 	if err != nil {
-		os.Exit(0)
+		hostname = "<unknown>"
 	}
-	fmt.Println(Logo)
 	pid := strconv.Itoa(os.Getpid())
 	starttime := time.Now().Format("2006-01-02 03:04:05 PM")
 	fmt.Println("		", VERSION)
 	fmt.Println("	Host: " + hostname)
-	fmt.Println("	Pid: " + string(pid))
-	fmt.Println("	Starttime: " + starttime)
+	fmt.Println("	Pid:", string(pid))
+	fmt.Println("	Proxy:", proxyhost)
+	fmt.Println("	Starttime:", starttime)
 	fmt.Println()
 }
 

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/bbangert/toml"
 	"github.com/golang/glog"
@@ -42,7 +43,8 @@ type ProxyConfig struct {
 
 func readConfig(file string) (pc ProxyConfig, connStr string) {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
-		glog.Fatalln(err)
+		glog.Errorln(err)
+		os.Exit(int(err.(syscall.Errno)))
 	}
 
 	if _, err := toml.DecodeFile(file, &pc); err != nil {

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -8,6 +8,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/bbangert/toml"
@@ -40,6 +41,10 @@ type ProxyConfig struct {
 }
 
 func readConfig(file string) (pc ProxyConfig, connStr string) {
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		glog.Fatalln(err)
+	}
+
 	if _, err := toml.DecodeFile(file, &pc); err != nil {
 		glog.Fatalln(err)
 	}

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -44,7 +44,7 @@ type ProxyConfig struct {
 func readConfig(file string) (pc ProxyConfig, connStr string) {
 	if _, err := os.Stat(file); os.IsNotExist(err) {
 		glog.Errorln(err)
-		os.Exit(int(err.(syscall.Errno)))
+		os.Exit(int(syscall.ENOENT))
 	}
 
 	if _, err := toml.DecodeFile(file, &pc); err != nil {


### PR DESCRIPTION
Check to see if the configuration file exists and exit if it doesn't to avoid cluttering up the screen with panic output:
```
17:47:02 c1-macbook (tl/check-if-config-exists) ~/Documents/Go/src/github.com/tonylambiris/pgproxy $ ./pgproxy
E0430 17:48:21.319894   31550 utils.go:46] stat ./pgproxy.conf: no such file or directory
```

This changes the default output of
```
17:48:35 c1-macbook (tl/check-if-config-exists) ~/Documents/Go/src/github.com/tonylambiris/pgproxy $ pgproxy 
F0430 17:48:37.866207   31572 utils.go:44] open ./pgproxy.conf: no such file or directory
goroutine 1 [running]:
github.com/golang/glog.stacks(0xc42008d400, 0xc4200b6420, 0x5a, 0xaf)
	/home/tlambiris/Documents/Go/src/github.com/golang/glog/glog.go:769 +0xa7
github.com/golang/glog.(*loggingT).output(0x825280, 0xc400000003, 0xc4200b6370, 0x7f681e, 0x8, 0x2c, 0x0)
	/home/tlambiris/Documents/Go/src/github.com/golang/glog/glog.go:720 +0x36b
github.com/golang/glog.(*loggingT).println(0x825280, 0x3, 0xc42005fe00, 0x1, 0x1)
	/home/tlambiris/Documents/Go/src/github.com/golang/glog/glog.go:633 +0xe7
github.com/golang/glog.Fatalln(0xc42005fe00, 0x1, 0x1)
	/home/tlambiris/Documents/Go/src/github.com/golang/glog/glog.go:1141 +0x53
github.com/wgliang/pgproxy/cli.readConfig(0x6de653, 0xe, 0xa9000000006c4800, 0x8, 0xc42005fec8, 0x4116fc, 0xc4200a2f60)
	/home/tlambiris/Documents/Go/src/github.com/wgliang/pgproxy/cli/utils.go:44 +0xfd
github.com/wgliang/pgproxy/cli.Main(0x0, 0x0, 0x0, 0x0)
	/home/tlambiris/Documents/Go/src/github.com/wgliang/pgproxy/cli/cli.go:36 +0x4ed
main.main()
	/home/tlambiris/Documents/Go/src/github.com/tonylambiris/pgproxy/main.go:13 +0x45
```

This pull request also adds a `-config` flag to give the ability to put the configuration file anywhere, and it also refrains from exiting if the hostname cannot be looked up (sets it to `<unknown>`)

Thanks!